### PR TITLE
bumped upper version bounds

### DIFF
--- a/streaming-utils.cabal
+++ b/streaming-utils.cabal
@@ -65,21 +65,21 @@ library
   other-extensions:    CPP, Trustworthy
   
   build-depends:       base >=4.7 && <5.0, 
-                       transformers >=0.4 && <0.5.3, 
+                       transformers >=0.4 && <0.6, 
                        mtl >=2.2 && <2.3,
-                       attoparsec > 0.13.0.0 && < 0.13.2.0,
-                       streaming >=  0.1.4.0 && < 0.1.4.8,
-                       streaming-bytestring >= 0.1.4.0 && < 0.1.4.8,
+                       attoparsec > 0.13.0.0 && < 0.14,
+                       streaming >=  0.1.4.0 && < 0.3,
+                       streaming-bytestring >= 0.1.4.0 && < 0.2,
                        bytestring > 0.10.0 && < 0.11.0,
                        pipes >= 4.0 && < 4.4,
                        network-simple,
                        network, 
                        http-client >=0.2 && <0.6, 
                        http-client-tls,
-                       aeson > 0.8 && <1.2,
-                       json-stream > 0.4.0 && < 0.4.2,
-                       resourcet > 1.0 && < 1.2,
-                       streaming-commons > 0.1.0 && < 0.1.18
+                       aeson > 0.8 && <2.0,
+                       json-stream > 0.4.0 && < 0.4.3,
+                       resourcet > 1.0 && < 1.3,
+                       streaming-commons > 0.1.0 && < 0.3
                       
   -- hs-source-dirs:      
   default-language:    Haskell2010


### PR DESCRIPTION
self explanatory: bumped upper version bounds in cabal file. builds now